### PR TITLE
docs: clarify event hub/leg lane policies

### DIFF
--- a/items/agents/knowledge/permissions-policy.txt
+++ b/items/agents/knowledge/permissions-policy.txt
@@ -43,6 +43,7 @@ Rails for GREEN:
   examples: add missing required keys with nulls, normalize https, reorder fields
 - Small data updates to event/venue files limited to “safe fields”:
   display_name, official_link, labels (≤50 lines diff, ≤10 files)
+- Add hub (events) / Add leg(s) (events): Yellow (PR-by-default)
 
 Rails for YELLOW:
 - Always PR (no direct commit)
@@ -55,6 +56,7 @@ Rails for YELLOW:
 - Deletes/renames/path moves
 - Bulk edits >200 lines or >10 files
 - Schema changes in shared includes (e.g., event-rules.json / venue-rules.json)
+- Change dates on a live leg (events): Red (explicit approval)
 
 Rails for RED:
 - PR with explicit checklist & rationale


### PR DESCRIPTION
## Summary
- document adding event hubs or legs requires Yellow lane PR
- note that changing dates on live legs needs Red approval

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f90331988327bd41897f3194b40c