### PR TITLE
Fix NextUp active trip selection naming collision

### DIFF
--- a/docs/schedule/index.html
+++ b/docs/schedule/index.html
@@ -142,7 +142,7 @@
     /* 3-column list rows (name | next-up | agg) */
     .row--3col{
       display:grid;
-      grid-template-columns: 1fr auto auto;
+      grid-template-columns: 1fr minmax(0, 1fr) auto;
       gap: 12px;
       align-items:center;
       justify-content: initial;
@@ -158,6 +158,8 @@
       font-variant-numeric: tabular-nums;
       color: rgba(209,213,219,0.85);
       font-size: 13px;
+      justify-self: center;
+      text-align: center;
     }
 
     /* Search ----------------------------------------------------- */
@@ -393,9 +395,9 @@
     .c4-a{ font-variant-numeric: tabular-nums; color: rgba(209,213,219,0.9); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .c4-b{ font-variant-numeric: tabular-nums; color: rgba(209,213,219,0.9); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .c4-c{ white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
-      .c4-grid{
+    .c4-grid{
       display: grid;
-      grid-template-columns: minmax(0,1fr) minmax(0,1fr) max-content;
+      grid-template-columns: minmax(0,1.2fr) minmax(0,1.2fr) max-content max-content max-content max-content;
       gap: 10px;
       align-items: center;
       min-width: 0;
@@ -407,7 +409,13 @@
       min-width: 0;
     }
     .c4g-b{ color: var(--muted); }
-    .c4g-c{ justify-self: end; font-variant-numeric: tabular-nums; }
+    .c4g-c,
+    .c4g-d,
+    .c4g-e,
+    .c4g-f{
+      justify-self: end;
+      font-variant-numeric: tabular-nums;
+    }
     .c4-d{ justify-self: end; display:inline-flex; align-items:center; justify-content:flex-end; white-space: nowrap; overflow:hidden; text-overflow: ellipsis; min-width:0; }
 
     .timeline-axis{ z-index: 30; }
@@ -527,14 +535,16 @@
     .badge--status-S{ background: rgba(59,130,246,0.14); border-color: rgba(59,130,246,0.5); }
     .badge--status-L{ background: rgba(245,158,11,0.16); border-color: rgba(245,158,11,0.55); }
 
-    .badge--type-J{ display: none; background: rgba(244,63,94,0.14); border-color: rgba(244,63,94,0.55); }
-    .badge--type-E{ display: none; background: rgba(168,85,247,0.14); border-color: rgba(168,85,247,0.55); }
-    .badge--type-H{ display: none; background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.55); }
+    .badge--type-J{ background: rgba(244,63,94,0.14); border-color: rgba(244,63,94,0.55); }
+    .badge--type-E{ background: rgba(168,85,247,0.14); border-color: rgba(168,85,247,0.55); }
+    .badge--type-H{ background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.55); }
 
     .badge--seq-O{ background: rgba(14,165,233,0.14); border-color: rgba(14,165,233,0.55); }
     .badge--seq-U{ background: rgba(148,163,184,0.14); border-color: rgba(148,163,184,0.55); }
 
     .card-line4.row--class{ font-size: 12px; font-weight: 600; }
+    .card-line4.row--class .badge--type,
+    .card-line4.row--class .badge--seq{ display:none; }
     .card-line4.row--entry{ font-size: 10px; font-weight: 300; color: var(--fh-sentiment-positive, #90e58c);
 }
     .card-line4.row--trip{ display: none; font-size: 9px; font-weight: 300; opacity: 0.95; }
@@ -554,22 +564,14 @@
     }
 
     .app.hide-header .app-header{
-      height: 0 !important;
       opacity: 0;
       transform: translateY(calc(-1 * var(--header-h)));
-      border-bottom: 0;
-      padding: 0;
-      overflow: hidden;
       pointer-events: none;
     }
 
     .app.hide-nav .app-nav{
-      height: 0 !important;
       opacity: 0;
       transform: translateY(var(--nav-h));
-      border-top: 0;
-      padding: 0;
-      overflow: hidden;
       pointer-events: none;
     }
 
@@ -624,6 +626,12 @@
       border-radius: 12px;
       background: rgba(255,255,255,0.02);
       border: 1px solid rgba(255,255,255,0.08);
+    }
+    .summary-place--tap{
+      cursor: pointer;
+    }
+    .summary-place--tap:active{
+      transform: translateY(1px);
     }
     .summary-place-k{ opacity:0.9; font-size:12px; }
     .summary-place-v{ font-weight:900; }


### PR DESCRIPTION
### Motivation
- Resolve an Uncaught SyntaxError caused by a duplicate identifier for the NextUp active-trip list.
- Ensure NextUp chooses from actual trip records and prefers active trips when presenting a next-up summary.
- Improve UX consistency for search focus, class navigation, and ring-card layout introduced in the schedule UI changes.

### Description
- Rename the local variable `activeList` to `activeTrips` in `fmtNextUpFromEntryKeys` to avoid the duplicate identifier error and ensure clarity. 
- Refine `fmtNextUpFromEntryKeys` to collect trips from `tIdx.byEntryKey`, prefer active trips when picking the best trip, and require the chosen trip be active to render NextUp. 
- Restore search caret/focus after rerender, add `makeNavAgg` and `addCardBottom` helpers, wire class-row taps to pre-fill the Classes list (`state.search.classes`) and route to `classes`, and update entry/trip rendering to use explicit `latestGO`/`latestStart` and stricter OOG visibility. 
- Update list/card layout to 3-column rows with centered mid-column content, expand the `.c4-grid` columns and badge exposures, and refactor Summary tiles and placings grid for placing-mode filtering. 

### Testing
- Searched for the duplicated identifier with `rg -n "activeList" docs/schedule/app.js` to locate the problem and verify replacement points. 
- Applied the variable rename and related edits and created a commit which completed successfully. 
- No automated UI tests were executed for this patch (previous Playwright screenshot attempt timed out), so runtime verification remains manual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b60e6de48327aea2e25f086f473b)