### PR TITLE
Render completed trips as grid rows in schedule ring cards

### DIFF
--- a/docs/schedule/app.js
+++ b/docs/schedule/app.js
@@ -1974,6 +1974,29 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
                 const score = (tt.latestScore != null && String(tt.latestScore) !== '') ? String(tt.latestScore) : '';
                 const placing = (tt.latestPlacing != null && String(tt.latestPlacing) !== '') ? String(tt.latestPlacing) : '';
                 const right = score || placing || '';
+                const isCompleted = normalizeStr(tt.latestStatus) === 'completed';
+
+                if (isCompleted) {
+                  const tripGrid = el('div', 'c4-grid');
+                  tripGrid.appendChild(el('span', 'c4g-a', ''));
+                  tripGrid.appendChild(el('span', 'c4g-b', (tt.trip_id != null ? String(tt.trip_id) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-c', (tt.latestPlacing != null ? String(tt.latestPlacing) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-d', (tt.lastScore != null ? String(tt.lastScore) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-e', (tt.lastTime != null ? String(tt.lastTime) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-f', ''));
+
+                  addLine4(
+                    gWrap,
+                    '',
+                    '',
+                    tripGrid,
+                    '',
+                    'row--trip',
+                    'row-alt',
+                    null
+                  );
+                  continue;
+                }
 
                 stripe++;
                 addLine4(


### PR DESCRIPTION
### Motivation
- Surface completed trip metrics in ring cards by rendering a dedicated grid-style row when a trip's `latestStatus` is `Completed` so trip identifiers and results are more visible.

### Description
- Added a conditional in `docs/schedule/app.js` using `normalizeStr(tt.latestStatus) === 'completed'` to detect completed trips before the existing trip row rendering.
- For completed trips, render a `card-line4 row--trip row-alt` that contains a `c4-grid` with the requested mapping: `c4g-a: ""`, `c4g-b: trip_id`, `c4g-c: latestPlacing`, `c4g-d: lastScore`, `c4g-e: lastTime`, and `c4g-f: ""`.
- Kept the existing non-completed trip path and navigation behavior (via `addLine4`) unchanged.

### Testing
- Ran `node --check docs/schedule/app.js` to verify syntax and it succeeded.
- Attempted to serve the site with `python3 -m http.server` and capture a screenshot via Playwright for visual verification, but the browser navigation failed with `ERR_EMPTY_RESPONSE` so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69853bcf6a58832780a0b49e4cffa889)