### PR TITLE
Highlight schedule rows when trip fields change

### DIFF
--- a/docs/schedule/index.html
+++ b/docs/schedule/index.html
@@ -559,6 +559,10 @@
 
     .row-alt{ background: rgba(255,255,255,0.03); }
     .card-line4.row--ring-peak{ background: rgba(255,255,255,0.06); }
+    .card-line4.row--changed{
+      background: rgba(250,204,21,0.16);
+      box-shadow: inset 0 0 0 1px rgba(250,204,21,0.35);
+    }
     .group-wrap.tint-C{ border-left: 3px solid rgba(16,185,129,0.6); }
     .group-wrap.tint-S{ border-left: 3px solid rgba(59,130,246,0.6); }
     .group-wrap.tint-L{ border-left: 3px solid rgba(245,158,11,0.65); }


### PR DESCRIPTION
### Motivation
- Visually indicate schedule rows whose trip-derived fields changed between refreshes for the keys `latestStart`, `latestStatus`, `latestGO`, and `lastOOG` (where `lastOOG` is used together with `total_trips` in the existing UI). 

### Description
- Track per-refresh snapshots of trips by adding `tripSnapshot` and `changeFlags` to `state` and new helpers `makeClassNumberKey` and `makeEntryKey` to derive stable keys.  
- Compute snapshots with `buildTripSnapshot` and diff them via `buildTripChangeFlags` during `loadAll()` to populate `state.changeFlags`.  
- Apply `row--changed` to class and entry rows in `renderRingCardsFromTrips` when a class or entry key appears in `changeFlags`, using a small `joinClasses` helper to combine stripe and change classes.  
- Add CSS styling for `.card-line4.row--changed` in `docs/schedule/index.html` to give changed rows a highlighted background and inset ring.  

### Testing
- Created a local HTTP server with `python -m http.server` in `docs/schedule` which started successfully.  
- Attempted an automated visual smoke test via Playwright to open `/index.html`, navigate to Schedule and capture a screenshot, but Playwright/Chromium crashed in this environment (browser launch failed with `TargetClosedError` / SIGSEGV), so the visual test did not complete.  
- No additional automated unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f80b6a00832786dcf86a338c1db8)