### PR TITLE
Show completed trip rows in schedule (JS + CSS)

### DIFF
--- a/docs/schedule/app.js
+++ b/docs/schedule/app.js
@@ -1974,6 +1974,29 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
                 const score = (tt.latestScore != null && String(tt.latestScore) !== '') ? String(tt.latestScore) : '';
                 const placing = (tt.latestPlacing != null && String(tt.latestPlacing) !== '') ? String(tt.latestPlacing) : '';
                 const right = score || placing || '';
+                const isCompleted = normalizeStr(tt.latestStatus) === 'completed';
+
+                if (isCompleted) {
+                  const tripGrid = el('div', 'c4-grid');
+                  tripGrid.appendChild(el('span', 'c4g-a', ''));
+                  tripGrid.appendChild(el('span', 'c4g-b', (tt.trip_id != null ? String(tt.trip_id) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-c', (tt.latestPlacing != null ? String(tt.latestPlacing) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-d', (tt.lastScore != null ? String(tt.lastScore) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-e', (tt.lastTime != null ? String(tt.lastTime) : '')));
+                  tripGrid.appendChild(el('span', 'c4g-f', ''));
+
+                  addLine4(
+                    gWrap,
+                    '',
+                    '',
+                    tripGrid,
+                    '',
+                    'row--trip',
+                    'row-alt',
+                    null
+                  );
+                  continue;
+                }
 
                 stripe++;
                 addLine4(

--- a/docs/schedule/index.html
+++ b/docs/schedule/index.html
@@ -556,6 +556,7 @@
  color: var(--fh-sentiment-positive, #90e58c);
 }
     .card-line4.row--trip{ display: none; font-size: 9px; font-weight: 300; opacity: 0.95; }
+    .card-line4.row--trip.row-alt{ display: grid; }
 
     .row-alt{ background: rgba(255,255,255,0.03); }
     .card-line4.row--ring-peak{ background: rgba(255,255,255,0.06); }


### PR DESCRIPTION
### Motivation
- Surface completed-trip metrics in ring card detail rows so completed trips (latestStatus = "Completed") display key identifiers and results more visibly.
- Preserve existing navigation/behavior for non-completed trip rows while adding a dedicated compact grid for completed rows.

### Description
- Added detection in `docs/schedule/app.js` using `normalizeStr(tt.latestStatus) === 'completed'` and render a `div.c4-grid` with columns mapped to trip id, placing, score, and time for completed trips.
- For completed trips the code calls `addLine4(..., tripGrid, ..., 'row--trip', 'row-alt', null)` and `continue`s to avoid the regular trip rendering path.
- Updated `docs/schedule/index.html` CSS to make `.card-line4.row--trip.row-alt` visible by setting `display: grid` so the completed-trip grid rows render correctly.

### Testing
- Served the site with `python3 -m http.server 4173 --directory /workspace/clear-round-datasets` and used a Playwright script to `page.goto('http://127.0.0.1:4173/docs/schedule/', wait_until='networkidle')` and capture a screenshot; the navigation and screenshot run succeeded and produced an artifact.
- Verified the modified CSS lines are present in `docs/schedule/index.html` and the app JS changes are present in `docs/schedule/app.js` via local inspection (no runtime errors observed during the HTTP/Playwright run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69853bcf6a58832780a0b49e4cffa889)