### PR TITLE
Only render completed/underway trip detail grid when trip data is present

### DIFF
--- a/docs/schedule/app.js
+++ b/docs/schedule/app.js
@@ -1974,6 +1974,35 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
                 const score = (tt.latestScore != null && String(tt.latestScore) !== '') ? String(tt.latestScore) : '';
                 const placing = (tt.latestPlacing != null && String(tt.latestPlacing) !== '') ? String(tt.latestPlacing) : '';
                 const right = score || placing || '';
+                const statusKey = normalizeStr(tt.latestStatus);
+                const isCompletedOrUnderway = statusKey === 'completed' || statusKey === 'underway';
+                const tripId = tt.trip_id != null ? String(tt.trip_id) : '';
+                const tripPlacing = tt.latestPlacing != null ? String(tt.latestPlacing) : '';
+                const tripScore = tt.lastScore != null ? String(tt.lastScore) : '';
+                const tripTime = tt.lastTime != null ? String(tt.lastTime) : '';
+                const hasTripData = Boolean(tripId || tripPlacing || tripScore || tripTime);
+
+                if (isCompletedOrUnderway && hasTripData) {
+                  const tripGrid = el('div', 'c4-grid');
+                  tripGrid.appendChild(el('span', 'c4g-a', ''));
+                  tripGrid.appendChild(el('span', 'c4g-b', tripId));
+                  tripGrid.appendChild(el('span', 'c4g-c', tripPlacing));
+                  tripGrid.appendChild(el('span', 'c4g-d', tripScore));
+                  tripGrid.appendChild(el('span', 'c4g-e', tripTime));
+                  tripGrid.appendChild(el('span', 'c4g-f', ''));
+
+                  addLine4(
+                    gWrap,
+                    '',
+                    '',
+                    tripGrid,
+                    '',
+                    'row--trip',
+                    'row-alt',
+                    null
+                  );
+                  continue;
+                }
 
                 stripe++;
                 addLine4(

--- a/docs/schedule/index.html
+++ b/docs/schedule/index.html
@@ -556,6 +556,7 @@
  color: var(--fh-sentiment-positive, #90e58c);
 }
     .card-line4.row--trip{ display: none; font-size: 9px; font-weight: 300; opacity: 0.95; }
+    .card-line4.row--trip.row-alt{ display: grid; }
 
     .row-alt{ background: rgba(255,255,255,0.03); }
     .card-line4.row--ring-peak{ background: rgba(255,255,255,0.06); }


### PR DESCRIPTION
### Motivation
- Avoid showing empty or placeholder trip detail rows by only exposing the compact detail grid when a trip is `completed` or `underway` and actual trip data exists.

### Description
- Add a normalized status check `isCompletedOrUnderway` for `tt.latestStatus` and require it alongside a `hasTripData` boolean before rendering the compact grid for a trip. 
- Convert trip fields (`trip_id`, `latestPlacing`, `lastScore`, `lastTime`) to strings and compute `hasTripData` from them to gate rendering. 
- Render the `div.c4-grid` detail row and call `addLine4(...)` only when both status and data checks pass, otherwise continue with the existing hidden/default trip row path. 
- Ensure the CSS includes `.card-line4.row--trip.row-alt{ display: grid; }` so the grid row displays when applicable.

### Testing
- Started a local static server with `python3 -m http.server 4173` and confirmed it served the site successfully. 
- Attempted to run a Playwright screenshot script, but Chromium crashed (SIGSEGV) in this environment so the screenshot could not be produced. 
- No automated unit tests were run; the change is a logic-only guard validated via file inspection and a local run attempt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69853bcf6a58832780a0b49e4cffa889)