### PR TITLE
Route class rows to class detail

### DIFF
--- a/docs/schedule/app.js
+++ b/docs/schedule/app.js
@@ -1842,8 +1842,9 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
               'row--class',
               (stripe % 2 === 0 ? 'row-alt' : ''),
               canClassNav ? (() => {
-                state.search.classes = String(c.class_name || '').trim();
-                goto('classes');
+                const classId = c.class_id != null ? String(c.class_id) : '';
+                if (!classId) return;
+                pushDetail('classDetail', { kind: 'class', key: classId });
               }) : null
             );
 


### PR DESCRIPTION
### Motivation
- Ensure clicking a class name on schedule ring cards navigates directly to the class detail view instead of performing a classes list search so the class title and ringcard appear on the detail page.

### Description
- Update `docs/schedule/app.js` so the class row click handler uses `pushDetail('classDetail', { kind: 'class', key: classId })` with `class_id` instead of setting `state.search.classes` and calling `goto('classes')`.

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983cb1803a883279acb7f0812eff17c)