### PR TITLE
Modernize schedule UI density and refactor mountShell + bucket rendering

### DIFF
--- a/docs/schedule/app.js
+++ b/docs/schedule/app.js
@@ -38,75 +38,101 @@
     const mount = document.getElementById('app');
     if (!mount) throw new Error('Missing #app mount');
 
-    // Clear (idempotent)
-    mount.innerHTML = '';
-
-    // Header
-    const header = document.createElement('header');
-    header.className = 'app-header';
-
-    const backBtn = document.createElement('button');
-    backBtn.className = 'header-back';
-    backBtn.id = 'header-back';
-    backBtn.type = 'button';
-    backBtn.innerHTML = '<span>&larr;</span>';
-
-    const title = document.createElement('h1');
-    title.className = 'header-title';
-    title.id = 'header-title';
-    title.textContent = 'Start';
-
-    const spacer = document.createElement('div');
-    spacer.className = 'header-spacer';
-    spacer.setAttribute('aria-hidden', 'true');
-
-    header.appendChild(backBtn);
-    header.appendChild(title);
-    header.appendChild(spacer);
-
-    // Main
-    const main = document.createElement('main');
-    main.className = 'app-main';
-    main.id = 'app-main';
-
-    const root = document.createElement('div');
-    root.id = 'screen-root';
-    root.className = 'list-column';
-    main.appendChild(root);
-
-    // Nav
-    const nav = document.createElement('nav');
-    nav.className = 'app-nav';
-
-    const navScroller = document.createElement('div');
-    navScroller.className = 'nav-scroller';
-
-    const navRowEl = document.createElement('div');
-    navRowEl.className = 'nav-row';
-    navRowEl.id = 'nav-row';
-
-    navRowEl.innerHTML = [
-      '<button class="nav-btn" type="button" data-screen="start"><span class="nav-label">Start</span></button>',
-      '<button class="nav-btn" type="button" data-screen="summary"><span class="nav-label">Summary</span></button>',
-      '<button class="nav-btn" type="button" data-screen="horses"><span class="nav-label">Horses</span><span class="nav-agg" data-nav-agg="horses">0</span></button>',
-      '<button class="nav-btn" type="button" data-screen="riders"><span class="nav-label">Riders</span><span class="nav-agg" data-nav-agg="riders">0</span></button>',
-      '<button class="nav-btn" type="button" data-screen="schedule"><span class="nav-label">Schedule</span><span class="nav-agg" data-nav-agg="schedule">0</span></button>',    ].join('');
-
-    navScroller.appendChild(navRowEl);
-    nav.appendChild(navScroller);
-
-    mount.appendChild(header);
-    mount.appendChild(main);
-    mount.appendChild(nav);
-
-    // Refs
     appEl = mount;
-    appMain = main;
-    screenRoot = root;
-    headerTitle = title;
-    headerBack = backBtn;
+
+    const header = mount.querySelector('.app-header');
+    const main = mount.querySelector('#app-main') || mount.querySelector('.app-main');
+    const root = mount.querySelector('#screen-root');
+    const nav = mount.querySelector('.app-nav');
+    const navScroller = nav && nav.querySelector('.nav-scroller');
+    const navRowEl = mount.querySelector('#nav-row');
+
+    if (!header || !main || !root || !nav || !navScroller || !navRowEl) {
+      // Fallback create (keeps idempotence for older shells)
+      mount.innerHTML = '';
+
+      const fallbackHeader = document.createElement('header');
+      fallbackHeader.className = 'app-header';
+
+      const fallbackBack = document.createElement('button');
+      fallbackBack.className = 'header-back';
+      fallbackBack.id = 'header-back';
+      fallbackBack.type = 'button';
+      fallbackBack.innerHTML = '<span>&larr;</span>';
+
+      const fallbackTitle = document.createElement('h1');
+      fallbackTitle.className = 'header-title';
+      fallbackTitle.id = 'header-title';
+      fallbackTitle.textContent = 'Start';
+
+      const fallbackSpacer = document.createElement('div');
+      fallbackSpacer.className = 'header-spacer';
+      fallbackSpacer.setAttribute('aria-hidden', 'true');
+
+      fallbackHeader.appendChild(fallbackBack);
+      fallbackHeader.appendChild(fallbackTitle);
+      fallbackHeader.appendChild(fallbackSpacer);
+
+      const fallbackMain = document.createElement('main');
+      fallbackMain.className = 'app-main';
+      fallbackMain.id = 'app-main';
+
+      const fallbackRoot = document.createElement('div');
+      fallbackRoot.id = 'screen-root';
+      fallbackRoot.className = 'list-column';
+      fallbackMain.appendChild(fallbackRoot);
+
+      const fallbackFilterBottom = document.createElement('div');
+      fallbackFilterBottom.id = 'filterbottom';
+      fallbackFilterBottom.className = 'filterbottom';
+      fallbackMain.appendChild(fallbackFilterBottom);
+
+      const fallbackNav = document.createElement('nav');
+      fallbackNav.className = 'app-nav';
+      fallbackNav.setAttribute('aria-label', 'Primary');
+
+      const fallbackScroller = document.createElement('div');
+      fallbackScroller.className = 'nav-scroller';
+
+      const fallbackNavRow = document.createElement('div');
+      fallbackNavRow.className = 'nav-row';
+      fallbackNavRow.id = 'nav-row';
+      fallbackNavRow.innerHTML = [
+        '<button class="nav-btn" type="button" data-screen="start"><span class="nav-label">Start</span></button>',
+        '<button class="nav-btn" type="button" data-screen="summary"><span class="nav-label">Summary</span></button>',
+        '<button class="nav-btn" type="button" data-screen="horses"><span class="nav-label">Horses</span><span class="nav-agg" data-nav-agg="horses">0</span></button>',
+        '<button class="nav-btn" type="button" data-screen="riders"><span class="nav-label">Riders</span><span class="nav-agg" data-nav-agg="riders">0</span></button>',
+        '<button class="nav-btn" type="button" data-screen="schedule"><span class="nav-label">Schedule</span><span class="nav-agg" data-nav-agg="schedule">0</span></button>'
+      ].join('');
+
+      fallbackScroller.appendChild(fallbackNavRow);
+      fallbackNav.appendChild(fallbackScroller);
+
+      mount.appendChild(fallbackHeader);
+      mount.appendChild(fallbackMain);
+      mount.appendChild(fallbackNav);
+
+      appMain = fallbackMain;
+      screenRoot = fallbackRoot;
+      headerTitle = fallbackTitle;
+      headerBack = fallbackBack;
+      navRow = fallbackNavRow;
+    } else {
+      appMain = main;
+      screenRoot = root;
+      headerTitle = mount.querySelector('#header-title');
+      headerBack = mount.querySelector('#header-back');
+      navRow = navRowEl;
+
+      if (!main.querySelector('#filterbottom')) {
+        const filterBottom = document.createElement('div');
+        filterBottom.id = 'filterbottom';
+        filterBottom.className = 'filterbottom';
+        main.appendChild(filterBottom);
+      }
+    }
+
     headerAction = document.getElementById('header-action'); // optional
-    navRow = navRowEl;
   }
 
   mountShell();
@@ -230,6 +256,7 @@
   // ----------------------------
   function el(tag, clsOrAttrs, text) {
     const n = document.createElement(tag);
+    if (tag === 'button') n.type = 'button';
 
     if (typeof clsOrAttrs === 'string') {
       if (clsOrAttrs) n.className = clsOrAttrs;
@@ -883,6 +910,7 @@
     input.type = 'text';
     input.placeholder = placeholder || 'Search...';
     input.value = state.search[screenKey] || '';
+    input.setAttribute('aria-label', placeholder || 'Search');
 
     input.addEventListener('input', () => {
       state.search[screenKey] = input.value;
@@ -1493,16 +1521,8 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
     }
 
     const bucketItems = buildBucketChipsFromTrips(baseTrips, 30);
-    const activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
-    const hasActive = bucketItems.some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
-    const bucketKey = hasActive ? activeBucket : null;
-
-    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
-
-    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
-    renderBucketFilterBottom(bucketItems, bucketKey);
-
-    applyPendingScroll();
+    const bucketKey = resolveBucketSelection(bucketItems);
+    renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey);
   }
 
 // ----------------------------
@@ -2139,6 +2159,20 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
 
 
 
+  function resolveBucketSelection(bucketItems) {
+    const activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
+    const hasActive = (bucketItems || []).some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
+    return hasActive ? activeBucket : null;
+  }
+
+  function renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey) {
+    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
+    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
+    renderBucketFilterBottom(bucketItems, bucketKey);
+    applyPendingScroll();
+  }
+
+
   function renderHorseDetail(sIdx, tIdx) {
     clearRoot();
 
@@ -2148,16 +2182,8 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
     const baseTrips = (state.trips || []).filter(t => String(t && t.horseName || '') === horseName);
 
     const bucketItems = buildBucketChipsFromTrips(baseTrips, 30);
-    const activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
-    const hasActive = bucketItems.some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
-    const bucketKey = hasActive ? activeBucket : null;
-
-    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
-
-    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
-    renderBucketFilterBottom(bucketItems, bucketKey);
-
-    applyPendingScroll();
+    const bucketKey = resolveBucketSelection(bucketItems);
+    renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey);
   }
 
   // ----------------------------
@@ -2307,16 +2333,8 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
     const baseTrips = (state.trips || []).filter(t => String(t && t.riderName || '') === riderName);
 
     const bucketItems = buildBucketChipsFromTrips(baseTrips, 30);
-    const activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
-    const hasActive = bucketItems.some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
-    const bucketKey = hasActive ? activeBucket : null;
-
-    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
-
-    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
-    renderBucketFilterBottom(bucketItems, bucketKey);
-
-    applyPendingScroll();
+    const bucketKey = resolveBucketSelection(bucketItems);
+    renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey);
   }
 
   // ----------------------------
@@ -2337,16 +2355,8 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
     const baseTrips = (state.trips || []).filter(t => String(t && t.class_id || '') === classId);
 
     const bucketItems = buildBucketChipsFromTrips(baseTrips, 30);
-    const activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
-    const hasActive = bucketItems.some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
-    const bucketKey = hasActive ? activeBucket : null;
-
-    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
-
-    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
-    renderBucketFilterBottom(bucketItems, bucketKey);
-
-    applyPendingScroll();
+    const bucketKey = resolveBucketSelection(bucketItems);
+    renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey);
   }
 
   // ----------------------------
@@ -2361,23 +2371,13 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
     const bucketItems = buildBucketChipsFromTrips(baseTrips, 30);
 
     // Default timeline to the first real bucket if none selected
-    let activeBucket = (state.filter && state.filter.bucket != null) ? String(state.filter.bucket) : null;
-    const realBuckets = bucketItems.filter(it => it.key != null);
-    if (!activeBucket && realBuckets.length) {
-      activeBucket = String(realBuckets[0].key);
-      state.filter.bucket = activeBucket;
+    if (state.filter.bucket == null) {
+      const realBuckets = bucketItems.filter(it => it.key != null);
+      if (realBuckets.length) state.filter.bucket = String(realBuckets[0].key);
     }
 
-    // If active bucket is not present, fall back to null (All)
-    const hasActive = bucketItems.some(it => (it.key == null && !activeBucket) || (it.key != null && String(it.key) === String(activeBucket)));
-    const bucketKey = hasActive ? activeBucket : null;
-
-    const viewTrips = filterTripsByBucket(baseTrips, bucketKey, 30);
-
-    renderRingCardsFromTrips(viewTrips, sIdx, { skipPeakBar: false });
-    renderBucketFilterBottom(bucketItems, bucketKey);
-
-    applyPendingScroll();
+    const bucketKey = resolveBucketSelection(bucketItems);
+    renderBucketedTrips(baseTrips, sIdx, bucketItems, bucketKey);
   }
 
   // ----------------------------
@@ -2386,9 +2386,8 @@ function makeCard(title, aggValue, inverseHdr, onClick) {
   function render() {
     if (!screenRoot || !headerTitle) return;
 
-    
     clearFilterBottom();
-const sIdx = buildScheduleIndex();
+    const sIdx = buildScheduleIndex();
     const tIdx = buildTruthIndex();
 
     renderAggs(sIdx, tIdx);
@@ -2450,7 +2449,6 @@ const sIdx = buildScheduleIndex();
       render();
     });
   }
-  // this is a new comment
   // ----------------------------
   // BOOT
   // ----------------------------

--- a/docs/schedule/index.html
+++ b/docs/schedule/index.html
@@ -9,12 +9,21 @@
     :root {
       --bg: #020617;
       --bg-alt: #0b1120;
-      --border: #374151;
-      --border-soft: #4b5563;
+      --border: #334155;
+      --border-soft: #475569;
       --accent: #2563eb;
+      --text-main: #e5e7eb;
+      --text-muted: #94a3b8;
+      --surface: #0f172a;
+      --surface-alt: #111827;
       --pill-radius: 999px;
-      --header-h: 52px;
-      --nav-h: 72px;
+      --header-h: 50px;
+      --nav-h: 68px;
+      --space-1: 4px;
+      --space-2: 8px;
+      --space-3: 12px;
+      --space-4: 16px;
+      --control-h: 42px;
     }
 
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
@@ -27,11 +36,16 @@
     body { display: flex; justify-content: center; align-items: stretch; }
     [hidden] { display: none !important; }
 
+    :is(.header-back, .nav-btn, .row--tap, .state-search-input):focus-visible {
+      outline: 2px solid rgba(37, 99, 235, 0.95);
+      outline-offset: 1px;
+    }
+
     .app {
       width: 100%;
       max-width: 480px;
       height: 100vh;
-      max-height: 720px;
+      max-height: 740px;
       margin: 4px;
       display: flex;
       flex-direction: column;
@@ -51,7 +65,7 @@
       display: grid;
       grid-template-columns: 60px 1fr 60px;
       align-items: center;
-      padding: 2px;
+      padding: 4px 6px;
       border-bottom: 1px solid rgba(31, 41, 55, 0.95);
       background: #020617;
       -webkit-backdrop-filter: blur(10px);
@@ -86,7 +100,7 @@
     .header-back:active { transform: translateY(1px) scale(0.97); }
 
     .header-title {
-      font-size: 16px;
+      font-size: 15px;
       font-weight: 600;
       margin: 0;
       padding: 0;
@@ -100,11 +114,11 @@
       flex: 1;
       display: flex; flex-direction: column; justify-content: space-between;
       overflow-y: auto;
-      padding: 2px 2px 2px;
+      padding: 4px 4px 2px;
       background: radial-gradient(circle at top, #111827 0, #020617 52%);
     }
 
-    .list-column { display: flex; flex-direction: column; gap: 4px; padding: 1px 1px; padding-bottom: 4px; }
+    .list-column { display: flex; flex-direction: column; gap: 6px; padding: 2px; padding-bottom: 6px; }
 
     /* Start logo ------------------------------------------------- */
     .start-logo {
@@ -117,16 +131,16 @@
     /* Rows ------------------------------------------------------- */
     .row {
       width: 100%;
-      min-height: 46px;
-      padding: 10px 16px;
+      min-height: var(--control-h);
+      padding: 8px 14px;
       border-radius: var(--pill-radius);
       border: 1px solid var(--border-soft);
       background: #111827;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      font-size: 14px;
-      color: #e5e7eb;
+      font-size: 13px;
+      color: var(--text-main);
       box-shadow: 0 1px 0 #020617;
     }
     .row-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding-right: 8px; }
@@ -169,13 +183,13 @@
     .state-search { margin: 4px 4px 2px; }
     .state-search-input {
       width: 100%;
-      padding: 10px 16px;
-      min-height: 46px;
+      padding: 8px 14px;
+      min-height: var(--control-h);
       border-radius: var(--pill-radius);
       border: 1px solid var(--border-soft);
       background: #020617;
       color: #f9fafb;
-      font-size: 14px;
+      font-size: 13px;
       outline: none;
       box-shadow: 0 1px 0 #020617;
     }
@@ -192,7 +206,7 @@
       backdrop-filter: blur(12px);
       display: flex;
       align-items: flex-start;
-      padding: 2px;
+      padding: 4px 6px;
     }
 
     .nav-scroller { overflow-x: auto; -webkit-overflow-scrolling: touch; white-space: nowrap; width: 100%; }
@@ -272,7 +286,7 @@
       border-bottom-color: rgba(37, 99, 235, 0.35);
     }
     .card-title{
-      font-size: 14px; font-weight: 600; color: #f9fafb;
+      font-size: 13px; font-weight: 600; color: #f9fafb;
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding-right: 8px;
     }
     /*.card-body{ padding: 6px 0; } */
@@ -529,7 +543,7 @@
       box-shadow: 0 -14px 30px rgba(0, 0, 0, 0.85);
       -webkit-backdrop-filter: blur(12px);
       backdrop-filter: blur(12px);
-      padding: 2px; 
+      padding: 4px 6px; 
 
       
     }
@@ -673,20 +687,25 @@
       <div class="header-spacer" aria-hidden="true"></div>
     </header>
 
-    <main class="app-main" id="app-main">
+    <main class="app-main" id="app-main" aria-live="polite">
       <div id="screen-root" class="list-column"></div>
       <div id="filterbottom" class="filterbottom"></div>
     </main>
 
-    <nav class="app-nav">
+    <nav class="app-nav" aria-label="Primary">
       <div class="nav-scroller">
         <div class="nav-row" id="nav-row">
           <button class="nav-btn" type="button" data-screen="start">
             <span class="nav-label">Start</span>
           </button>
 
+          <button class="nav-btn" type="button" data-screen="summary">
+            <span class="nav-label">Summary</span>
+          </button>
+
           <button class="nav-btn" type="button" data-screen="schedule">
             <span class="nav-label">Schedule</span>
+            <span class="nav-agg" data-nav-agg="schedule">0</span>
           </button>
           
           <button class="nav-btn" type="button" data-screen="horses">


### PR DESCRIPTION
### Motivation

- Reduce visual clutter and tighten the schedule UI for a denser data-app layout while keeping all runtime hooks intact.
- Remove duplicated bucket-selection rendering across detail/timeline screens and centralize the logic to make future tweaks safer. 
- Make the client shell resilient to either a static server-provided DOM or the JS-created DOM by preferring the existing DOM and falling back to creation.

### Description

- Updated `docs/schedule/index.html` styling: tightened spacing, reduced control heights, adjusted typography scale, added focus-visible ring, and exposed a few new CSS variables for consistent spacing and control sizing; preserved IDs/classes used by the app. 
- Added small accessibility improvements in `index.html` such as `aria-live=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fc9719e188327a505ea64807f77f0)