### PR TITLE
Refactor schedule bottom nav to config-driven tabs with badge support

### DIFF
--- a/docs/schedule/app.v2_792f.js
+++ b/docs/schedule/app.v2_792f.js
@@ -67,6 +67,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   const topTitle = document.getElementById('topTitle');
   const btnBack = document.getElementById('btnBack');
   const btnRefresh = document.getElementById('btnRefresh');
+  const navList = document.getElementById('navList');
 
   const views = {
     start: document.getElementById('view-start'),
@@ -114,6 +115,8 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   const state = {
     
     flySmsBody: '',activeView: 'start',
+    activeTabId: 'start',
+    navProfile: 'legacy',
     globalStatus: '',   // '', 'U','L','C'
     activeHorse: '',    //
     activeGroom: '',
@@ -127,6 +130,61 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     ringsIndex: [], // {ring_number, ringName}
     lastLoadedAt: null,
     errors: []
+  };
+
+  const NAV_CONFIG = {
+    default: {
+      fallback: 'start',
+      tabsByView: {
+        '*': ['start','summary','lite','full','threads','horses'],
+        horses: ['start','summary','lite','horses'],
+        threads: ['start','summary','lite','threads','horses'],
+      },
+      tabs: {
+        start:   { label: 'Start', view: 'start' },
+        summary: { label: 'Time', view: 'summary' },
+        lite:    { label: 'Pro', view: 'lite' },
+        full:    { label: 'Full', view: 'full' },
+        threads: { label: 'Schooling Bridles', view: 'threads', countSource: 'schoolingBridles' },
+        horses:  { label: 'Active Horses', view: 'horses', countSource: 'activeHorses' },
+      },
+    },
+    legacy: {
+      fallback: 'start',
+      tabsByView: {
+        '*': ['start','summary','lite','full','threads','horses'],
+      },
+      tabs: {
+        start:   { label: 'Start', view: 'start' },
+        summary: { label: 'Time', view: 'summary' },
+        lite:    { label: 'Pro', view: 'lite' },
+        full:    { label: 'Full', view: 'full' },
+        threads: { label: 'Threads', view: 'threads' },
+        horses:  { label: 'Horses', view: 'horses' },
+      },
+    },
+  };
+
+  const NAV_COUNT_SOURCES = {
+    activeHorses: () => {
+      const set = new Set();
+      state.trips.forEach(r => {
+        const horse = String(r.horseName || '').trim();
+        if (!horse || isHorseInactive(horse)) return;
+        set.add(horse.toLowerCase());
+      });
+      return set.size;
+    },
+    schoolingBridles: () => {
+      let count = 0;
+      state.trips.forEach(r => {
+        const raw = String(r.schoolingBridles ?? r.schooling_bridles ?? r.bridles ?? '').trim().toLowerCase();
+        if (!raw) return;
+        if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'none') return;
+        count += 1;
+      });
+      return count;
+    },
   };
 
   // ------------------------------------------------
@@ -266,6 +324,65 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     return state.activeView === 'full' ? ringsFullEl : ringsLiteEl;
   }
 
+  function getNavProfile(){
+    const hasBadgeData = state.trips.some(r =>
+      r.schoolingBridles != null || r.schooling_bridles != null || r.bridles != null
+    );
+    return hasBadgeData ? 'default' : 'legacy';
+  }
+
+  function getNavConfig(){
+    return NAV_CONFIG[state.navProfile] || NAV_CONFIG.legacy;
+  }
+
+  function getTabsForView(viewKey){
+    const cfg = getNavConfig();
+    const tabsByView = cfg.tabsByView || {};
+    const ids = tabsByView[viewKey] || tabsByView['*'] || [];
+    return ids.map(id => ({ id, ...(cfg.tabs[id] || {}) })).filter(t => t.view);
+  }
+
+  function getBadgeCount(countSource){
+    const fn = NAV_COUNT_SOURCES[countSource];
+    if (!fn) return null;
+    const n = Number(fn());
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+
+  function renderNav(currentView){
+    if (!navList) return;
+    const tabs = getTabsForView(currentView);
+    navList.innerHTML = '';
+    tabs.forEach(tab => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'nav-tab';
+      b.setAttribute('data-nav-id', tab.id);
+      b.setAttribute('data-nav-view', tab.view);
+
+      const isActive = (tab.view === currentView) || (tab.id === state.activeTabId && !tabs.some(t => t.view === currentView));
+      b.classList.toggle('is-active', isActive);
+
+      const label = document.createElement('span');
+      label.textContent = tab.label || tab.id;
+      b.appendChild(label);
+
+      const badge = getBadgeCount(tab.countSource);
+      if (badge != null){
+        const pill = document.createElement('span');
+        pill.className = 'nav-tab__badge';
+        pill.textContent = String(badge);
+        b.appendChild(pill);
+      }
+
+      b.addEventListener('click', () => {
+        state.activeTabId = tab.id;
+        setView(tab.view, { tabId: tab.id });
+      });
+      navList.appendChild(b);
+    });
+  }
+
   // ------------------------------------------------
   // Chrome hide/show on scroll
   // ------------------------------------------------
@@ -291,32 +408,35 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   // ------------------------------------------------
   // Views / nav
   // ------------------------------------------------
-  function setView(viewKey){
+  function setView(viewKey, options={}){
+    const cfg = getNavConfig();
+    const targetView = views[viewKey] ? viewKey : (cfg.fallback || 'start');
+    const activeTabId = options.tabId || state.activeTabId || targetView;
+
     const prevView = state.activeView;
-    state.activeView = viewKey;
+    state.activeView = targetView;
+    state.activeTabId = activeTabId;
 
-    if (prevView !== viewKey) closeFly();
+    if (prevView !== targetView) closeFly();
 
-    Object.keys(views).forEach(k => views[k].classList.toggle('is-active', k === viewKey));
-    document.querySelectorAll('.nav-btn[data-view]').forEach(b => {
-      b.classList.toggle('is-active', b.getAttribute('data-view') === viewKey);
-    });
+    Object.keys(views).forEach(k => views[k].classList.toggle('is-active', k === targetView));
+    renderNav(targetView);
 
     // Filters: Pro + Full + Time use horse/groom filters; Pro only uses status; Pro/Full only use peaks
-    const showBottomFilters = (viewKey === 'lite' || viewKey === 'full' || viewKey === 'summary');
-    statusWrap.hidden = !(viewKey === 'lite' || viewKey === 'summary');
-    peaksWrap.hidden  = !(viewKey === 'lite' || viewKey === 'full' || viewKey === 'summary');
+    const showBottomFilters = (targetView === 'lite' || targetView === 'full' || targetView === 'summary');
+    statusWrap.hidden = !(targetView === 'lite' || targetView === 'summary');
+    peaksWrap.hidden  = !(targetView === 'lite' || targetView === 'full' || targetView === 'summary');
     horsesWrap.hidden = !showBottomFilters;
-    if (groomsWrap) groomsWrap.hidden = !(viewKey === 'lite' || viewKey === 'summary');
-    app.classList.toggle('filters--on', (viewKey === 'lite' || viewKey === 'summary'));
-    app.classList.toggle('filters--peaks', (viewKey === 'full'));
+    if (groomsWrap) groomsWrap.hidden = !(targetView === 'lite' || targetView === 'summary');
+    app.classList.toggle('filters--on', (targetView === 'lite' || targetView === 'summary'));
+    app.classList.toggle('filters--peaks', (targetView === 'full'));
     app.classList.toggle('filters--bottom', false);
 
-    topTitle.textContent = viewKey === 'lite' ? 'Pro'
-                       : viewKey === 'full' ? 'Full Schedule'
-                       : viewKey === 'threads' ? 'Threads'
-                       : viewKey === 'horses' ? 'Horses'
-                       : viewKey === 'summary' ? 'Time'
+    topTitle.textContent = targetView === 'lite' ? 'Pro'
+                       : targetView === 'full' ? 'Full Schedule'
+                       : targetView === 'threads' ? 'Threads'
+                       : targetView === 'horses' ? 'Horses'
+                       : targetView === 'summary' ? 'Time'
                        : 'Start';
 
     // Collapse sticky gaps based on which filter rows are visible
@@ -337,10 +457,6 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     // re-render peaks active state, because scroll targets differ by view
     renderPeaks();
   }
-
-  document.querySelectorAll('.nav-btn[data-view]').forEach(b => {
-    b.addEventListener('click', () => setView(b.getAttribute('data-view')));
-  });
 
   btnRefresh.addEventListener('click', () => {
     app.classList.remove('chrome--hidden');
@@ -874,6 +990,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
       }
 
       state.lastLoadedAt = new Date().toISOString();
+      state.navProfile = getNavProfile();
 
       indexEntriesById();
       indexRings();
@@ -885,6 +1002,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
       renderLiteAndFull();
       renderThreads();
       renderHorses();
+      renderNav(state.activeView);
 
       // auto switch to Lite once loaded (only if user hasn't navigated)
       if (!force && state.activeView === 'start') {

--- a/docs/schedule/index.v2_792f.html
+++ b/docs/schedule/index.v2_792f.html
@@ -221,38 +221,63 @@
     .app.chrome--hidden .bottomnav{
       transform: translateX(-50%) translateY(calc(var(--nav-h) + env(safe-area-inset-bottom) + 6px));
     }
-    .nav-grid{
+    .nav-list{
       height: var(--nav-h);
-      display:grid;
-      grid-template-columns: repeat(6, 1fr);
-      justify-items: center;
-      gap: 8px;
-      padding: 10px var(--pad);
-    }
-    .nav-btn{
-      height: 42px;
-      min-width: 62px;
-      max-width: 86px;
-      width: auto;
-      padding: 0 10px;
-      border-radius: var(--r-pill);
-      border: 1px solid rgba(255,255,255,.12);
-      background: rgba(255,255,255,.04);
-      color: rgba(255,255,255,.88);
       display:flex;
       align-items:center;
+      gap: 8px;
+      padding: 9px var(--pad);
+      overflow-x:auto;
+      scrollbar-width:none;
+    }
+    .nav-list::-webkit-scrollbar{ display:none; }
+    .nav-tab{
+      height: 44px;
+      min-width: 64px;
+      max-width: 124px;
+      width: auto;
+      padding: 0 11px;
+      border-radius: var(--r-pill);
+      border: 1px solid rgba(255,255,255,.16);
+      background: rgba(255,255,255,.04);
+      color: rgba(255,255,255,.88);
+      display:inline-flex;
+      align-items:center;
       justify-content:center;
+      gap: 6px;
       font-size: var(--fs-2);
       font-weight: 600;
       user-select:none;
       white-space:nowrap;
       cursor:pointer;
+      flex: 0 0 auto;
+      transition: border-color .16s ease, background .16s ease, box-shadow .16s ease, color .16s ease;
     }
-    .nav-btn:active{ transform: translateY(1px) scale(.995); }
-    .nav-btn.is-active{
-      border-color: rgba(47,107,255,.55);
-      background: rgba(47,107,255,.16);
+    .nav-tab:active{ transform: translateY(1px) scale(.995); }
+    .nav-tab.is-active{
+      border-color: rgba(47,107,255,.80);
+      background: rgba(47,107,255,.22);
       color:#fff;
+      box-shadow: 0 0 0 1px rgba(47,107,255,.25), 0 8px 24px rgba(47,107,255,.22);
+    }
+    .nav-tab__badge{
+      min-width: 16px;
+      height: 16px;
+      padding: 0 5px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.20);
+      background: rgba(255,255,255,.14);
+      color: rgba(255,255,255,.95);
+      font-size: var(--fs-0);
+      font-weight: 700;
+      line-height: 1;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .nav-tab.is-active .nav-tab__badge{
+      border-color: rgba(47,107,255,.72);
+      background: rgba(15,42,120,.62);
     }
 
     /* ---------------------------------------------------------
@@ -1064,7 +1089,7 @@
     .t-go{ color: rgba(47,107,255,.95); }
 
 /* Focus */
-    :is(.sbtn,.peakbtn,.hchip,.nav-btn,.epill,.fly_btn,.tb-btn,.ring_btn):focus-visible{
+    :is(.sbtn,.peakbtn,.hchip,.nav-btn,.nav-tab,.epill,.fly_btn,.tb-btn,.ring_btn):focus-visible{
       outline: 2px solid rgba(47,107,255,.95);
       outline-offset: 2px;
     }
@@ -1317,14 +1342,7 @@
     </div>
 
     <div class="bottomnav" id="bottomnav">
-      <div class="nav-grid" aria-label="Bottom navigation">
-        <div class="nav-btn is-active" data-view="start">Start</div>
-        <div class="nav-btn" data-view="summary">Time</div>
-        <div class="nav-btn" data-view="lite">Pro</div>
-        <div class="nav-btn" data-view="full">Full</div>
-        <div class="nav-btn" data-view="threads">Threads</div>
-        <div class="nav-btn" data-view="horses">Horses</div>
-      </div>
+      <div class="nav-list" id="navList" aria-label="Bottom navigation"></div>
     </div>
 
     <div class="fly" id="fly">


### PR DESCRIPTION
### Motivation
- Replace the fixed 6-column navigation with a flexible, data-driven tab list so different views/profiles can present variable tab sets and counts.
- Add small count badges for tabs (e.g. Active Horses / Schooling Bridles) and apply branded active states while preserving existing safe-area and `chrome--hidden` behaviors.
- Provide a legacy fallback so older flows continue to work when badge data is not available.

### Description
- Replaced static markup and styles: `nav-grid` / `.nav-btn` → dynamic `#navList` container plus `.nav-list`, `.nav-tab`, and `.nav-tab__badge` styles in `docs/schedule/index.v2_792f.html` to support horizontal overflow, badge pills, and enhanced active glow/border states.
- Added config-driven nav model in `docs/schedule/app.v2_792f.js`: `NAV_CONFIG` (tab metadata and per-view tab sets), `NAV_COUNT_SOURCES` (badge count providers), and state fields `navProfile` / `activeTabId` to select profile and remember active tab.
- Implemented navigation helpers: `getNavProfile()`, `getNavConfig()`, `getTabsForView()`, `getBadgeCount()` and `renderNav()` which build the tab buttons from config and optionally render badge pills only when counts exist.
- Updated `setView()` and click wiring to use the config map (resolve target view + tab id), to call `renderNav()` and to preserve existing filter visibility, safe-area spacing, and `chrome--hidden` transitions; `loadAll()` now detects profile and refreshes the nav after data loads.
- Kept legacy behavior as a fallback profile so if badge data is absent the classic tab labels and flows render unchanged.

### Testing
- Ran `node --check docs/schedule/app.v2_792f.js` to verify JS syntax and it completed successfully.
- Served the site with `python3 -m http.server 8000 --directory /workspace/clear-round-datasets` and captured a Playwright screenshot of the updated nav to validate layout and badges, which succeeded.
- Verified the changes were committed (`git commit`) and the JS boot path (`setView('start')` + `loadAll()`) runs in the modified bundle without runtime syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a733b31b708327850b5e61da657851)