### PR TITLE
Add dynamic bottom navigation with tab counts and start-page UI updates

### DIFF
--- a/docs/schedule/app.v2_792f.js
+++ b/docs/schedule/app.v2_792f.js
@@ -67,6 +67,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   const topTitle = document.getElementById('topTitle');
   const btnBack = document.getElementById('btnBack');
   const btnRefresh = document.getElementById('btnRefresh');
+  const navList = document.getElementById('navList');
 
   const views = {
     start: document.getElementById('view-start'),
@@ -89,7 +90,8 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   const start_threads = document.getElementById('start_threads');
   const startRowPro = document.getElementById('startRowPro');
   const startRowHorses = document.getElementById('startRowHorses');
-  const startDetailsLink = document.getElementById('startDetailsLink');
+  const startRowSummary = document.getElementById('startRowSummary');
+  const startRowRestart = document.getElementById('startRowRestart');
   const startPanelData = document.getElementById('startPanelData');
 
   const time_container = document.getElementById('time_container');
@@ -114,6 +116,8 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   const state = {
     
     flySmsBody: '',activeView: 'start',
+    activeTabId: 'start',
+    navProfile: 'legacy',
     globalStatus: '',   // '', 'U','L','C'
     activeHorse: '',    //
     activeGroom: '',
@@ -127,6 +131,59 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     ringsIndex: [], // {ring_number, ringName}
     lastLoadedAt: null,
     errors: []
+  };
+
+  const NAV_CONFIG = {
+    default: {
+      fallback: 'start',
+      tabsByView: {
+        '*': ['start','horses','threads'],
+        horses: ['start','horses','threads'],
+        threads: ['start','horses','threads'],
+      },
+      tabs: {
+        start:   { label: 'Start', view: 'start' },
+        horses:  { label: 'Active Horses', view: 'horses', countSource: 'activeHorses' },
+        threads: { label: 'Schooling Bridles', view: 'threads', countSource: 'schoolingBridles' },
+      },
+    },
+    legacy: {
+      fallback: 'start',
+      tabsByView: {
+        '*': ['start','horses','threads'],
+      },
+      tabs: {
+        start:   { label: 'Start', view: 'start' },
+        horses:  { label: 'Active Horses', view: 'horses' },
+        threads: { label: 'Schooling Bridles', view: 'threads' },
+      },
+    },
+  };
+
+  const NAV_COUNT_SOURCES = {
+    activeHorses: () => {
+      const set = new Set();
+      state.trips.forEach(r => {
+        const horse = String(r.horseName || '').trim();
+        if (!horse || isHorseInactive(horse)) return;
+        set.add(horse.toLowerCase());
+      });
+      return { available: true, count: set.size };
+    },
+    schoolingBridles: () => {
+      let available = false;
+      let count = 0;
+      state.trips.forEach(r => {
+        const rawValue = r.schoolingBridles ?? r.schooling_bridles ?? r.bridles;
+        if (rawValue == null || String(rawValue).trim() === '') return;
+        available = true;
+
+        const raw = String(rawValue).trim().toLowerCase();
+        if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'none') return;
+        count += 1;
+      });
+      return { available, count };
+    },
   };
 
   // ------------------------------------------------
@@ -266,6 +323,66 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     return state.activeView === 'full' ? ringsFullEl : ringsLiteEl;
   }
 
+  function getNavProfile(){
+    const qp = new URLSearchParams(window.location.search || '');
+    if (qp.get('nav') === 'legacy' || qp.get('profile') === 'legacy') return 'legacy';
+    return state.trips.length ? 'default' : 'legacy';
+  }
+
+  function getNavConfig(){
+    return NAV_CONFIG[state.navProfile] || NAV_CONFIG.legacy;
+  }
+
+  function getTabsForView(viewKey){
+    const cfg = getNavConfig();
+    const tabsByView = cfg.tabsByView || {};
+    const ids = tabsByView[viewKey] || tabsByView['*'] || [];
+    return ids.map(id => ({ id, ...(cfg.tabs[id] || {}) })).filter(t => t.view);
+  }
+
+  function getBadgeCount(countSource){
+    const fn = NAV_COUNT_SOURCES[countSource];
+    if (!fn) return null;
+    const meta = fn();
+    if (!meta || !meta.available) return null;
+    const n = Number(meta.count);
+    return Number.isFinite(n) && n >= 0 ? n : null;
+  }
+
+  function renderNav(currentView){
+    if (!navList) return;
+    const tabs = getTabsForView(currentView);
+    navList.innerHTML = '';
+    tabs.forEach(tab => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'nav-tab';
+      b.setAttribute('data-nav-id', tab.id);
+      b.setAttribute('data-nav-view', tab.view);
+
+      const isActive = (tab.view === currentView) || (tab.id === state.activeTabId && !tabs.some(t => t.view === currentView));
+      b.classList.toggle('is-active', isActive);
+
+      const label = document.createElement('span');
+      label.textContent = tab.label || tab.id;
+      b.appendChild(label);
+
+      const badge = getBadgeCount(tab.countSource);
+      if (badge != null){
+        const pill = document.createElement('span');
+        pill.className = 'nav-tab__badge';
+        pill.textContent = String(badge);
+        b.appendChild(pill);
+      }
+
+      b.addEventListener('click', () => {
+        state.activeTabId = tab.id;
+        setView(tab.view, { tabId: tab.id });
+      });
+      navList.appendChild(b);
+    });
+  }
+
   // ------------------------------------------------
   // Chrome hide/show on scroll
   // ------------------------------------------------
@@ -291,32 +408,35 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
   // ------------------------------------------------
   // Views / nav
   // ------------------------------------------------
-  function setView(viewKey){
+  function setView(viewKey, options={}){
+    const cfg = getNavConfig();
+    const targetView = views[viewKey] ? viewKey : (cfg.fallback || 'start');
+    const activeTabId = options.tabId || state.activeTabId || targetView;
+
     const prevView = state.activeView;
-    state.activeView = viewKey;
+    state.activeView = targetView;
+    state.activeTabId = activeTabId;
 
-    if (prevView !== viewKey) closeFly();
+    if (prevView !== targetView) closeFly();
 
-    Object.keys(views).forEach(k => views[k].classList.toggle('is-active', k === viewKey));
-    document.querySelectorAll('.nav-btn[data-view]').forEach(b => {
-      b.classList.toggle('is-active', b.getAttribute('data-view') === viewKey);
-    });
+    Object.keys(views).forEach(k => views[k].classList.toggle('is-active', k === targetView));
+    renderNav(targetView);
 
     // Filters: Pro + Full + Time use horse/groom filters; Pro only uses status; Pro/Full only use peaks
-    const showBottomFilters = (viewKey === 'lite' || viewKey === 'full' || viewKey === 'summary');
-    statusWrap.hidden = !(viewKey === 'lite' || viewKey === 'summary');
-    peaksWrap.hidden  = !(viewKey === 'lite' || viewKey === 'full' || viewKey === 'summary');
+    const showBottomFilters = (targetView === 'lite' || targetView === 'full' || targetView === 'summary');
+    statusWrap.hidden = !(targetView === 'lite' || targetView === 'summary');
+    peaksWrap.hidden  = !(targetView === 'lite' || targetView === 'full' || targetView === 'summary');
     horsesWrap.hidden = !showBottomFilters;
-    if (groomsWrap) groomsWrap.hidden = !(viewKey === 'lite' || viewKey === 'summary');
-    app.classList.toggle('filters--on', (viewKey === 'lite' || viewKey === 'summary'));
-    app.classList.toggle('filters--peaks', (viewKey === 'full'));
+    if (groomsWrap) groomsWrap.hidden = !(targetView === 'lite' || targetView === 'summary');
+    app.classList.toggle('filters--on', (targetView === 'lite' || targetView === 'summary'));
+    app.classList.toggle('filters--peaks', (targetView === 'full'));
     app.classList.toggle('filters--bottom', false);
 
-    topTitle.textContent = viewKey === 'lite' ? 'Pro'
-                       : viewKey === 'full' ? 'Full Schedule'
-                       : viewKey === 'threads' ? 'Threads'
-                       : viewKey === 'horses' ? 'Horses'
-                       : viewKey === 'summary' ? 'Time'
+    topTitle.textContent = targetView === 'lite' ? 'Pro'
+                       : targetView === 'full' ? 'Full Schedule'
+                       : targetView === 'threads' ? 'Threads'
+                       : targetView === 'horses' ? 'Horses'
+                       : targetView === 'summary' ? 'Time'
                        : 'Start';
 
     // Collapse sticky gaps based on which filter rows are visible
@@ -337,10 +457,6 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
     // re-render peaks active state, because scroll targets differ by view
     renderPeaks();
   }
-
-  document.querySelectorAll('.nav-btn[data-view]').forEach(b => {
-    b.addEventListener('click', () => setView(b.getAttribute('data-view')));
-  });
 
   btnRefresh.addEventListener('click', () => {
     app.classList.remove('chrome--hidden');
@@ -363,17 +479,27 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
       main.scrollTo({ top: 0, behavior: 'smooth' });
     });
   }
-  if (startDetailsLink && startPanelData){
-    // default hidden
-    startPanelData.hidden = true;
-    startDetailsLink.textContent = 'Session details';
-    startDetailsLink.addEventListener('click', (e) => {
-      e.preventDefault();
-      const willShow = startPanelData.hidden;
-      startPanelData.hidden = !willShow;
-      startDetailsLink.textContent = willShow ? 'Hide session details' : 'Session details';
+  if (startRowSummary){
+    startRowSummary.addEventListener('click', () => {
+      setView('summary');
+      main.scrollTo({ top: 0, behavior: 'smooth' });
     });
   }
+  if (startRowRestart){
+    startRowRestart.addEventListener('click', () => {
+      state.globalStatus = '';
+      state.activeHorse = '';
+      state.activeGroom = '';
+      state.activeRing = '';
+      app.classList.remove('chrome--hidden');
+      setView('start');
+      main.scrollTo({ top: 0, behavior: 'smooth' });
+      buildHorseChips();
+      renderLiteAndFull();
+      renderPeaks();
+    });
+  }
+  if (startPanelData){ startPanelData.hidden = true; }
 
   // ------------------------------------------------
   // Filters (global status + horse)
@@ -874,6 +1000,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
       }
 
       state.lastLoadedAt = new Date().toISOString();
+      state.navProfile = getNavProfile();
 
       indexEntriesById();
       indexRings();
@@ -885,6 +1012,7 @@ const URL_TRIPS    = urlCandidates('watch_trips.json');
       renderLiteAndFull();
       renderThreads();
       renderHorses();
+      renderNav(state.activeView);
 
       // auto switch to Lite once loaded (only if user hasn't navigated)
       if (!force && state.activeView === 'start') {

--- a/docs/schedule/index.v2_792f.html
+++ b/docs/schedule/index.v2_792f.html
@@ -221,38 +221,62 @@
     .app.chrome--hidden .bottomnav{
       transform: translateX(-50%) translateY(calc(var(--nav-h) + env(safe-area-inset-bottom) + 6px));
     }
-    .nav-grid{
+    .nav-list{
       height: var(--nav-h);
-      display:grid;
-      grid-template-columns: repeat(6, 1fr);
-      justify-items: center;
-      gap: 8px;
-      padding: 10px var(--pad);
-    }
-    .nav-btn{
-      height: 42px;
-      min-width: 62px;
-      max-width: 86px;
-      width: auto;
-      padding: 0 10px;
-      border-radius: var(--r-pill);
-      border: 1px solid rgba(255,255,255,.12);
-      background: rgba(255,255,255,.04);
-      color: rgba(255,255,255,.88);
       display:flex;
       align-items:center;
+      gap: 8px;
+      padding: 9px var(--pad);
+      overflow-x:auto;
+      scrollbar-width:none;
+    }
+    .nav-list::-webkit-scrollbar{ display:none; }
+    .nav-tab{
+      height: 44px;
+      min-width: 64px;
+      width: auto;
+      padding: 0 11px;
+      border-radius: var(--r-pill);
+      border: 1px solid rgba(255,255,255,.16);
+      background: rgba(255,255,255,.04);
+      color: rgba(255,255,255,.88);
+      display:inline-flex;
+      align-items:center;
       justify-content:center;
+      gap: 6px;
       font-size: var(--fs-2);
       font-weight: 600;
       user-select:none;
       white-space:nowrap;
       cursor:pointer;
+      flex: 0 0 auto;
+      transition: border-color .16s ease, background .16s ease, box-shadow .16s ease, color .16s ease;
     }
-    .nav-btn:active{ transform: translateY(1px) scale(.995); }
-    .nav-btn.is-active{
-      border-color: rgba(47,107,255,.55);
-      background: rgba(47,107,255,.16);
+    .nav-tab:active{ transform: translateY(1px) scale(.995); }
+    .nav-tab.is-active{
+      border-color: rgba(47,107,255,.80);
+      background: rgba(47,107,255,.22);
       color:#fff;
+      box-shadow: 0 0 0 1px rgba(47,107,255,.25), 0 8px 24px rgba(47,107,255,.22);
+    }
+    .nav-tab__badge{
+      min-width: 16px;
+      height: 16px;
+      padding: 0 5px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.20);
+      background: rgba(255,255,255,.14);
+      color: rgba(255,255,255,.95);
+      font-size: var(--fs-0);
+      font-weight: 700;
+      line-height: 1;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .nav-tab.is-active .nav-tab__badge{
+      border-color: rgba(47,107,255,.72);
+      background: rgba(15,42,120,.62);
     }
 
     /* ---------------------------------------------------------
@@ -1064,7 +1088,7 @@
     .t-go{ color: rgba(47,107,255,.95); }
 
 /* Focus */
-    :is(.sbtn,.peakbtn,.hchip,.nav-btn,.epill,.fly_btn,.tb-btn,.ring_btn):focus-visible{
+    :is(.sbtn,.peakbtn,.hchip,.nav-btn,.nav-tab,.epill,.fly_btn,.tb-btn,.ring_btn):focus-visible{
       outline: 2px solid rgba(47,107,255,.95);
       outline-offset: 2px;
     }
@@ -1113,6 +1137,11 @@
       background: rgba(0,0,0,.22);
       flex: 0 0 auto;
     }
+    .rowtap__dot.is-on{
+      border-color: rgba(48,199,89,.78);
+      background: rgba(48,199,89,.34);
+      box-shadow: 0 0 0 1px rgba(48,199,89,.26);
+    }
 
     .panel__link{
       display:inline-block;
@@ -1123,6 +1152,35 @@
       text-underline-offset: 3px;
       cursor:pointer;
       user-select:none;
+    }
+
+    .start-hero{
+      margin: 2px 0 8px;
+      border-radius: var(--r-2);
+      border: 0;
+      background: transparent;
+      padding: 6px 2px 12px;
+      text-align:center;
+    }
+    .start-hero__eyebrow{
+      font-size: var(--fs-1);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,.66);
+      font-weight: 700;
+    }
+    .start-hero__title{
+      margin-top: 6px;
+      font-size: 22px;
+      line-height: 1.1;
+      font-weight: 800;
+      color: rgba(255,255,255,.98);
+    }
+    .start-hero__sub{
+      margin-top: 6px;
+      font-size: var(--fs-3);
+      font-weight: 500;
+      color: rgba(255,255,255,.82);
     }
 
     /* Groom chips (above horse chips) */
@@ -1212,22 +1270,34 @@
       <div class="view is-active" id="view-start">
         <div class="panel">
           <div class="panel__title">Start</div>
+
+          <div class="start-hero" aria-label="Company hero">
+            <div class="start-hero__title">TackLists.com</div>
+            <div class="start-hero__sub">Quick horse tack lists, on the fly.</div>
+          </div>
+
           <button class="rowtap" id="startRowPro" type="button">
             <div class="rowtap__main">
-              <div class="rowtap__title">RingStatus.com</div>
-              <div class="rowtap__sub">Your Show Day Schedule - Fast!</div>
+              <div class="rowtap__sub" style="margin-top:0; color:rgba(255,255,255,.94); font-weight:700;">In-session</div>
             </div>
-            <div class="rowtap__dot" aria-hidden="true"></div>
+            <div class="rowtap__dot is-on" aria-hidden="true"></div>
           </button>
 
-          <button class="rowtap" id="startRowHorses" type="button">
+          <button class="rowtap" id="startRowSummary" type="button">
             <div class="rowtap__main">
-              <div class="rowtap__title">Active Horses</div>
+              <div class="rowtap__sub" style="margin-top:0; color:rgba(255,255,255,.92);">Summary</div>
             </div>
             <div class="rowtap__dot" aria-hidden="true"></div>
           </button>
 
-          <a class="panel__link" href="#" id="startDetailsLink">Session details</a>
+          <button class="rowtap" id="startRowRestart" type="button">
+            <div class="rowtap__main">
+              <div class="rowtap__sub" style="margin-top:0; color:rgba(255,255,255,.92);">Restart session</div>
+            </div>
+            <div class="rowtap__dot" aria-hidden="true"></div>
+          </button>
+
+          <div class="start-hero__sub" style="font-size:11px; margin:8px 2px 0; color:rgba(255,255,255,.72); text-align:left;">Autosave: ON (device).</div>
 
           <div id="startPanelData" hidden>
 
@@ -1317,14 +1387,7 @@
     </div>
 
     <div class="bottomnav" id="bottomnav">
-      <div class="nav-grid" aria-label="Bottom navigation">
-        <div class="nav-btn is-active" data-view="start">Start</div>
-        <div class="nav-btn" data-view="summary">Time</div>
-        <div class="nav-btn" data-view="lite">Pro</div>
-        <div class="nav-btn" data-view="full">Full</div>
-        <div class="nav-btn" data-view="threads">Threads</div>
-        <div class="nav-btn" data-view="horses">Horses</div>
-      </div>
+      <div class="nav-list" id="navList" aria-label="Bottom navigation"></div>
     </div>
 
     <div class="fly" id="fly">


### PR DESCRIPTION
### Motivation
- Introduce a flexible, data-driven bottom navigation that adapts to available data and query parameters and surfaces simple aggregated counts. 
- Improve the Start view UX with a compact hero, clearer quick actions and a restart action for session state.

### Description
- Add dynamic nav system: introduce `navList` element, `NAV_CONFIG`, `NAV_COUNT_SOURCES`, `getNavProfile`, `getNavConfig`, `getTabsForView`, `getBadgeCount` and `renderNav` to compute and render tabs and badges at runtime. 
- Update navigation handling by changing `setView` to `setView(viewKey, options={})`, respect nav config fallback, maintain `state.activeTabId`, and call `renderNav` when views or data change. 
- Compute counts for badges via `NAV_COUNT_SOURCES` (including `activeHorses` and `schoolingBridles`) and wire tab click handlers to set `state.activeTabId` and change view. 
- Replace static bottom nav markup and CSS grid with a scrollable, responsive tab list (`.nav-list` / `.nav-tab`) and add visual styles for badges and active state. 
- Modify Start view markup and handlers: add `start-hero` content, replace `startDetailsLink` behavior with `startRowSummary` and `startRowRestart` rows, and add a restart action that resets session filters and rebuilds UI (`buildHorseChips`, `renderLiteAndFull`, `renderPeaks`).
- Wire `state.navProfile` selection from `getNavProfile()` during data load so the nav adapts to query params or whether trips exist. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a733b31b708327850b5e61da657851)